### PR TITLE
PINTAIL-92 dynamically discover partitions

### DIFF
--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -216,9 +216,9 @@ public abstract class AbstractMessagingDatabusConsumer
 
   /**
    * @return Message if Message is available on the stream
-   * Otherwise waits for the Message to be available on the stream
+   *          Otherwise waits for the Message to be available on the stream
    * @throws throws an EndOfStreamException When consumer consumed all messages
-   *                till stopTime
+   *  till stopTime
    */
   @Override
   protected Message getNext()
@@ -240,9 +240,9 @@ public abstract class AbstractMessagingDatabusConsumer
 
   /**
    * @return Message if Message is available on the stream
-   * Null if Message is not available on the stream for a given timeout
+   *          Null if Message is not available on the stream for a given timeout
    * @throws throws an EndOfStreamException When consumer consumed all messages
-   *                till stopTime
+   *  till stopTime
    */
   @Override
   protected Message getNext(long timeout, TimeUnit timeunit)

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -434,11 +434,11 @@ public abstract class AbstractMessagingDatabusConsumer
    * modifying the cluster names with the user provided cluster names
    */
   protected void preparePartitionIdMap(ClientConfig config,
-      String[] rootDirStrs, String[] clusterNames,
+      String[] rootDirStrs, String [] clusterNames,
       Map<PartitionId, PartitionId> partitionIdMap) {
     String clusterNameStr = config.getString(clustersNameConfig);
     if (clusterNameStr != null) {
-      String[] clusterNameStrs = clusterNameStr.split(",");
+      String [] clusterNameStrs = clusterNameStr.split(",");
       if (clusterNameStrs.length != rootDirStrs.length) {
         throw new IllegalArgumentException("Cluster names were not specified for all root dirs."
             + " Mismatch between number of root dirs and number of user specified cluster names");

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -58,6 +58,8 @@ public abstract class AbstractMessagingDatabusConsumer
   protected final Map<PartitionId, PartitionReader> readers =
       new HashMap<PartitionId, PartitionReader>();
 
+  protected final Set<PartitionReader> startedReaders = new HashSet<PartitionReader>();
+
   protected Map<PartitionId, Boolean> messageConsumedMap = new HashMap
       <PartitionId, Boolean>();
 
@@ -199,6 +201,10 @@ public abstract class AbstractMessagingDatabusConsumer
     return readers;
   }
 
+  public Set<PartitionReader> getStartedPartitionReaders() {
+      return startedReaders;
+    }
+
   protected abstract void createCheckpoint();
 
   public Set<Integer> getPartitionMinList() {
@@ -283,7 +289,11 @@ public abstract class AbstractMessagingDatabusConsumer
   protected synchronized void start() throws IOException {
     createPartitionReaders();
     for (PartitionReader reader : readers.values()) {
+      if(startedReaders.contains(reader)){
+        continue;
+      }
       reader.start(getReaderNameSuffix());
+      startedReaders.add(reader);
     }
   }
 
@@ -390,6 +400,7 @@ public abstract class AbstractMessagingDatabusConsumer
       removeStatsExposer(reader.getStatsExposer());
     }
     readers.clear();
+    startedReaders.clear();
     if (buffer != null) {
       buffer.clear();
     }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -200,10 +200,6 @@ public abstract class AbstractMessagingDatabusConsumer
     return readers;
   }
 
-  public Set<PartitionReader> getStartedPartitionReaders() {
-    return startedReaders;
-  }
-
   protected abstract void createCheckpoint();
 
   public Set<Integer> getPartitionMinList() {
@@ -288,15 +284,12 @@ public abstract class AbstractMessagingDatabusConsumer
   protected synchronized void start() throws IOException {
     createPartitionReaders();
     for (PartitionReader reader : readers.values()) {
-      if (startedReaders.contains(reader)) {
-        continue;
-      }
       reader.start(getReaderNameSuffix());
       startedReaders.add(reader);
     }
   }
 
-  private String getReaderNameSuffix() {
+  protected String getReaderNameSuffix() {
     StringBuilder str = new StringBuilder();
     str.append(topicName);
     str.append("-");
@@ -461,16 +454,6 @@ public abstract class AbstractMessagingDatabusConsumer
       }
     } else {
       LOG.info("using default cluster names as clustersName config is missing");
-    }
-  }
-
-  protected synchronized void startNewReaders() {
-    for (PartitionReader reader : readers.values()) {
-      if (startedReaders.contains(reader)) {
-        continue;
-      }
-      reader.start(getReaderNameSuffix());
-      startedReaders.add(reader);
     }
   }
 }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -173,7 +173,7 @@ public abstract class AbstractMessagingDatabusConsumer
     relativeStartTimeStr = config.getString(relativeStartTimeConfig);
 
     if (relativeStartTimeStr == null && retentionInHours != null) {
-      LOG.warn(retentionConfig + " is deprecated."
+      LOG.warn(retentionConfig  + " is deprecated."
           + " Use " + relativeStartTimeConfig + " instead");
       int minutes = (Integer.parseInt(retentionInHours)) * 60;
       relativeStartTimeStr = String.valueOf(minutes);

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -416,7 +416,7 @@ public abstract class AbstractMessagingDatabusConsumer
   }
 
   protected void parseClusterNamesAndMigrateCheckpoint(ClientConfig config,
-                                                       String[] rootDirStrs) {
+      String[] rootDirStrs) {
     Map<PartitionId, PartitionId> partitionIdMap = new HashMap<PartitionId, PartitionId>();
     preparePartitionIdMap(config, rootDirStrs, clusterNames, partitionIdMap);
 
@@ -434,8 +434,8 @@ public abstract class AbstractMessagingDatabusConsumer
    * modifying the cluster names with the user provided cluster names
    */
   protected void preparePartitionIdMap(ClientConfig config,
-                                       String[] rootDirStrs, String[] clusterNames,
-                                       Map<PartitionId, PartitionId> partitionIdMap) {
+      String[] rootDirStrs, String[] clusterNames,
+      Map<PartitionId, PartitionId> partitionIdMap) {
     String clusterNameStr = config.getString(clustersNameConfig);
     if (clusterNameStr != null) {
       String[] clusterNameStrs = clusterNameStr.split(",");

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -59,7 +59,6 @@ public abstract class AbstractMessagingDatabusConsumer
       new HashMap<PartitionId, PartitionReader>();
 
   protected final Set<PartitionReader> startedReaders = new HashSet<PartitionReader>();
-
   protected Map<PartitionId, Boolean> messageConsumedMap = new HashMap
       <PartitionId, Boolean>();
 
@@ -174,7 +173,7 @@ public abstract class AbstractMessagingDatabusConsumer
     relativeStartTimeStr = config.getString(relativeStartTimeConfig);
 
     if (relativeStartTimeStr == null && retentionInHours != null) {
-      LOG.warn(retentionConfig  + " is deprecated."
+      LOG.warn(retentionConfig + " is deprecated."
           + " Use " + relativeStartTimeConfig + " instead");
       int minutes = (Integer.parseInt(retentionInHours)) * 60;
       relativeStartTimeStr = String.valueOf(minutes);
@@ -202,8 +201,8 @@ public abstract class AbstractMessagingDatabusConsumer
   }
 
   public Set<PartitionReader> getStartedPartitionReaders() {
-      return startedReaders;
-    }
+    return startedReaders;
+  }
 
   protected abstract void createCheckpoint();
 
@@ -220,10 +219,10 @@ public abstract class AbstractMessagingDatabusConsumer
   }
 
   /**
-   * @throws throws an EndOfStreamException When consumer consumed all messages
-   *  till stopTime
    * @return Message if Message is available on the stream
-   *         Otherwise waits for the Message to be available on the stream
+   * Otherwise waits for the Message to be available on the stream
+   * @throws throws an EndOfStreamException When consumer consumed all messages
+   *                till stopTime
    */
   @Override
   protected Message getNext()
@@ -244,10 +243,10 @@ public abstract class AbstractMessagingDatabusConsumer
   }
 
   /**
-   * @throws throws an EndOfStreamException When consumer consumed all messages
-   *  till stopTime
    * @return Message if Message is available on the stream
-   *         Null if Message is not available on the stream for a given timeout
+   * Null if Message is not available on the stream for a given timeout
+   * @throws throws an EndOfStreamException When consumer consumed all messages
+   *                till stopTime
    */
   @Override
   protected Message getNext(long timeout, TimeUnit timeunit)
@@ -289,7 +288,7 @@ public abstract class AbstractMessagingDatabusConsumer
   protected synchronized void start() throws IOException {
     createPartitionReaders();
     for (PartitionReader reader : readers.values()) {
-      if(startedReaders.contains(reader)){
+      if (startedReaders.contains(reader)) {
         continue;
       }
       reader.start(getReaderNameSuffix());
@@ -424,7 +423,7 @@ public abstract class AbstractMessagingDatabusConsumer
   }
 
   protected void parseClusterNamesAndMigrateCheckpoint(ClientConfig config,
-      String[] rootDirStrs) {
+                                                       String[] rootDirStrs) {
     Map<PartitionId, PartitionId> partitionIdMap = new HashMap<PartitionId, PartitionId>();
     preparePartitionIdMap(config, rootDirStrs, clusterNames, partitionIdMap);
 
@@ -442,11 +441,11 @@ public abstract class AbstractMessagingDatabusConsumer
    * modifying the cluster names with the user provided cluster names
    */
   protected void preparePartitionIdMap(ClientConfig config,
-      String[] rootDirStrs, String [] clusterNames,
-      Map<PartitionId, PartitionId> partitionIdMap) {
+                                       String[] rootDirStrs, String[] clusterNames,
+                                       Map<PartitionId, PartitionId> partitionIdMap) {
     String clusterNameStr = config.getString(clustersNameConfig);
     if (clusterNameStr != null) {
-      String [] clusterNameStrs = clusterNameStr.split(",");
+      String[] clusterNameStrs = clusterNameStr.split(",");
       if (clusterNameStrs.length != rootDirStrs.length) {
         throw new IllegalArgumentException("Cluster names were not specified for all root dirs."
             + " Mismatch between number of root dirs and number of user specified cluster names");
@@ -462,6 +461,16 @@ public abstract class AbstractMessagingDatabusConsumer
       }
     } else {
       LOG.info("using default cluster names as clustersName config is missing");
+    }
+  }
+
+  protected synchronized void startNewReaders() {
+    for (PartitionReader reader : readers.values()) {
+      if (startedReaders.contains(reader)) {
+        continue;
+      }
+      reader.start(getReaderNameSuffix());
+      startedReaders.add(reader);
     }
   }
 }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/AbstractMessagingDatabusConsumer.java
@@ -58,7 +58,6 @@ public abstract class AbstractMessagingDatabusConsumer
   protected final Map<PartitionId, PartitionReader> readers =
       new HashMap<PartitionId, PartitionReader>();
 
-  protected final Set<PartitionReader> startedReaders = new HashSet<PartitionReader>();
   protected Map<PartitionId, Boolean> messageConsumedMap = new HashMap
       <PartitionId, Boolean>();
 
@@ -285,7 +284,6 @@ public abstract class AbstractMessagingDatabusConsumer
     createPartitionReaders();
     for (PartitionReader reader : readers.values()) {
       reader.start(getReaderNameSuffix());
-      startedReaders.add(reader);
     }
   }
 
@@ -392,7 +390,6 @@ public abstract class AbstractMessagingDatabusConsumer
       removeStatsExposer(reader.getStatsExposer());
     }
     readers.clear();
-    startedReaders.clear();
     if (buffer != null) {
       buffer.clear();
     }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
@@ -149,8 +149,11 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
       public void run() {
         try {
           if (initDone) {
+            LOG.info("collector discoverer activated");
             createPartitionReaders();
             startNewReaders();
+          } else {
+            LOG.info("Init not done for consumer yet. Discoverer backing off");
           }
         } catch (IOException e) {
           e.printStackTrace();
@@ -158,6 +161,7 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
       }
     }, initialDelay * NUMBER_OF_MILLI_SECONDS_IN_SECOND,
         discoverFrequency * NUMBER_OF_MILLI_SECONDS_IN_SECOND);
+    LOG.info("Initialised timer for discovery of new collectors output with frequency "+discoverFrequency+" startup delay "+initialDelay);
   }
 
   private void getClusterNames(ClientConfig config, String[] rootDirSplits) {
@@ -313,11 +317,12 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
     super.close();
   }
 
-  protected synchronized void startNewReaders() {
+  protected void startNewReaders() {
     for (PartitionReader reader : readers.values()) {
       if (startedReaders.contains(reader)) {
         continue;
       }
+      LOG.info("started reader "+getReaderNameSuffix()+" "+reader.toString());
       reader.start(getReaderNameSuffix());
       startedReaders.add(reader);
     }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
@@ -149,6 +149,7 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
           if (initDone) {
             LOG.info("collector discoverer activated");
             createPartitionReaders();
+            LOG.info("Start new readers activated");
             startNewReaders();
           } else {
             LOG.info("Init not done for consumer yet. Discoverer backing off");
@@ -164,7 +165,7 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
   private void getClusterNames(ClientConfig config, String[] rootDirSplits) {
     String clusterNameStr = config.getString(clustersNameConfig);
     if (clusterNameStr != null) {
-      String[] clusterNameStrs = clusterNameStr.split(",");
+      String [] clusterNameStrs = clusterNameStr.split(",");
       if (clusterNameStrs.length != rootDirSplits.length) {
         throw new IllegalArgumentException("Cluster names were not specified for all root dirs."
             + " Mismatch between number of root dirs and number of user specified cluster names");
@@ -228,7 +229,7 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
         LOG.info("Creating partition reader for cluster");
         PartitionId id = new PartitionId(clusterName, null);
         PartitionCheckpointList partitionCheckpointList =
-            ((CheckpointList) currentCheckpoint).preaprePartitionCheckPointList(id);
+        ((CheckpointList) currentCheckpoint).preaprePartitionCheckPointList(id);
         Date partitionTimestamp = getPartitionTimestamp(id,
             partitionCheckpointList);
         LOG.debug("Creating partition " + id);

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
@@ -41,18 +41,18 @@ import com.inmobi.messaging.metrics.PartitionReaderStatsExposer;
 
 /**
  * Consumes data from the configured databus stream topic.
- * <p/>
+ *
  * Initializes the databus configuration from the configuration file specified
  * by the configuration {@value DatabusConsumerConfig#databusConfigFileKey},
  * the default value is
  * {@value DatabusConsumerConfig#DEFAULT_DATABUS_CONFIG_FILE}
- * <p/>
+ *
  * Consumer can specify a comma separated list of clusters from which the stream
  * should be streamed via configuration
  * {@value DatabusConsumerConfig#databusClustersConfig}. If no
  * such configuration exists, it will stream from all the source clusters of the
  * stream.
- * <p/>
+ *
  * This consumer supports mark and reset. Whenever user calls mark, the current
  * consumption will be check-pointed in a directory configurable via
  * {@value DatabusConsumerConfig#checkpointDirConfig}. The default value for
@@ -60,20 +60,20 @@ import com.inmobi.messaging.metrics.PartitionReaderStatsExposer;
  * directory is {@value DatabusConsumerConfig#DEFAULT_CHECKPOINT_DIR}. After
  * reset(), consumer will start reading
  * messages from last check-pointed position.
- * <p/>
+ *
  * Maximum consumer buffer size is configurable via
  * {@value DatabusConsumerConfig#queueSizeConfig}.
  * The default value is {@value DatabusConsumerConfig#DEFAULT_QUEUE_SIZE}.
- * <p/>
+ *
  * If consumer is reading from the file that is currently being written by
  * producer, consumer will wait for flush to happen on the file. The wait time
  * for flush is configurable via
  * {@value DatabusConsumerConfig#waitTimeForFlushConfig}, and default
  * value is {@value DatabusConsumerConfig#DEFAULT_WAIT_TIME_FOR_FLUSH}
- * <p/>
+ *
  * Initializes partition readers for each active collector on the stream.
  * TODO: Dynamically detect if new collectors are added and start readers for
- * them
+ *  them
  */
 public class DatabusConsumer extends AbstractMessagingDatabusConsumer
     implements DatabusConsumerConfig {
@@ -154,7 +154,6 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
         + " queueSize:" + bufferSize + " checkPoint:" + currentCheckpoint
         + " streamType:" + streamType);
   }
-
 
   private void getClusterNames(ClientConfig config, String[] rootDirSplits) {
     String clusterNameStr = config.getString(clustersNameConfig);

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
@@ -311,7 +311,7 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
       reader.start(getReaderNameSuffix());
       readers.put(id, reader);
       LOG.info("started new reader " + getReaderNameSuffix() +
-          " " + reader.toString());
+          " for partition " + id.toString());
     }
     newReaders.clear();
   }
@@ -341,8 +341,7 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
               if (initDone) {
                 LOG.info("collector discoverer activated");
                 createPartitionReaders();
-                LOG.info("Start new readers activated");
-                startNewReaders();
+                 startNewReaders();
               } else {
                 LOG.info("Init not done for consumer yet. Discoverer backing off");
               }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumer.java
@@ -181,7 +181,6 @@ public class DatabusConsumer extends AbstractMessagingDatabusConsumer
     return collectors;
   }
 
-
   protected void createPartitionReaders() throws IOException {
     for (int i = 0; i < rootDirs.length; i++) {
       LOG.debug("Creating partition readers for rootDir:" + rootDirs[i]);

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
@@ -34,5 +34,5 @@ public interface DatabusConsumerConfig extends MessagingConsumerConfig {
   "databus.consumer.waittime.forcollectorflush";
   public static final long DEFAULT_WAIT_TIME_FOR_FLUSH = 5000; // 5 second
   public static final String frequencyForDiscoverer =  "databus.consumer.collector.discoverer.frequency.seconds"; // in seconds
-  public static final int  DEFAULT_FREQUENCY_FOR_DISCOVERER = 120; // 2 minutes
+  public static final int  DEFAULT_FREQUENCY_FOR_DISCOVERER = 1200; // 20 minutes
 }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
@@ -33,4 +33,8 @@ public interface DatabusConsumerConfig extends MessagingConsumerConfig {
   public static final String waitTimeForFlushConfig =
   "databus.consumer.waittime.forcollectorflush";
   public static final long DEFAULT_WAIT_TIME_FOR_FLUSH = 5000; // 5 second
+  public static final String initialDelayForDiscoverer = "databus.consumer.initial.delay.minutes"; // in minutes
+  public static final int  DEFAULT_INITIAL_DELAY_FOR_DISCOVERER = 30; // 30 minutes
+  public static final String frequencyForDiscoverer =  "databus.consumer.discover.partition.frequency.minutes"; // in minutes
+  public static final int  DEFAULT_FREQUENCY_FOR_DISCOVERER = 2; // 2 minutes
 }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
@@ -33,8 +33,8 @@ public interface DatabusConsumerConfig extends MessagingConsumerConfig {
   public static final String waitTimeForFlushConfig =
   "databus.consumer.waittime.forcollectorflush";
   public static final long DEFAULT_WAIT_TIME_FOR_FLUSH = 5000; // 5 second
-  public static final String initialDelayForDiscoverer = "databus.consumer.initial.delay.minutes"; // in minutes
-  public static final int  DEFAULT_INITIAL_DELAY_FOR_DISCOVERER = 30; // 30 minutes
-  public static final String frequencyForDiscoverer =  "databus.consumer.discover.partition.frequency.minutes"; // in minutes
-  public static final int  DEFAULT_FREQUENCY_FOR_DISCOVERER = 2; // 2 minutes
+  public static final String initialDelayForDiscoverer = "databus.consumer.collector.discoverer.initial.delay.seconds"; // in seconds
+  public static final int  DEFAULT_INITIAL_DELAY_FOR_DISCOVERER = 1800; // 30 seconds
+  public static final String frequencyForDiscoverer =  "databus.consumer.collector.discoverer.frequency.seconds"; // in seconds
+  public static final int  DEFAULT_FREQUENCY_FOR_DISCOVERER = 120; // 2 minutes
 }

--- a/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
+++ b/messaging-client-databus/src/main/java/com/inmobi/messaging/consumer/databus/DatabusConsumerConfig.java
@@ -33,8 +33,6 @@ public interface DatabusConsumerConfig extends MessagingConsumerConfig {
   public static final String waitTimeForFlushConfig =
   "databus.consumer.waittime.forcollectorflush";
   public static final long DEFAULT_WAIT_TIME_FOR_FLUSH = 5000; // 5 second
-  public static final String initialDelayForDiscoverer = "databus.consumer.collector.discoverer.initial.delay.seconds"; // in seconds
-  public static final int  DEFAULT_INITIAL_DELAY_FOR_DISCOVERER = 1800; // 30 seconds
   public static final String frequencyForDiscoverer =  "databus.consumer.collector.discoverer.frequency.seconds"; // in seconds
   public static final int  DEFAULT_FREQUENCY_FOR_DISCOVERER = 120; // 2 minutes
 }

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestAbstractDatabusConsumer.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestAbstractDatabusConsumer.java
@@ -65,6 +65,7 @@ public abstract class TestAbstractDatabusConsumer {
   protected String ck11;
   protected String ck12;
   protected String ck13;
+  protected String ck14;
   protected String chkpointPathPrefix;
 
   public void setup(int numFileToMove) throws Exception {
@@ -131,6 +132,7 @@ public abstract class TestAbstractDatabusConsumer {
     ck11 = new Path(chkpointPathPrefix, "checkpoint11").toString();
     ck12 = new Path(chkpointPathPrefix, "checkpoint12").toString();
     ck13 = new Path(chkpointPathPrefix, "checkpoint13").toString();
+    ck14 = new Path(chkpointPathPrefix, "checkpoint14").toString();
   }
 
   protected DatabusConsumer getConsumerInstance() {

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
@@ -75,6 +75,19 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
     ConsumerUtil.testMarkAndReset(config, testStream, consumerName, false);
   }
 
+  @Test(timeOut = 10000)
+    public void testDynamicCollector() throws Exception {
+      ClientConfig config = loadConfig();
+      config.set(DatabusConsumerConfig.databusRootDirsConfig,
+          rootDirs[0].toUri().toString());
+      config.set(DatabusConsumerConfig.checkpointDirConfig, ck14);
+      config.set(MessagingConsumerConfig.relativeStartTimeConfig,
+          relativeStartTime);
+      ConsumerUtil.testDynamicCollector(config, testStream, consumerName, false,rootDirs,conf,testStream,COLLECTOR_PREFIX);
+    }
+
+
+
   @Test
   public void testMarkAndResetWithStartTime() throws Exception {
     ClientConfig config = loadConfig();
@@ -256,6 +269,7 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
     ConsumerUtil.testConsumerWithStartOfStream(config, testStream, consumerName,
         false);
   }
+
 
   @AfterTest
   public void cleanup() throws IOException {

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
@@ -83,8 +83,7 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
       config.set(DatabusConsumerConfig.checkpointDirConfig, ck14);
       config.set(MessagingConsumerConfig.relativeStartTimeConfig,
           relativeStartTime);
-      config.set(DatabusConsumerConfig.initialDelayForDiscoverer, "1");
-      config.set(DatabusConsumerConfig.frequencyForDiscoverer, "1");
+       config.set(DatabusConsumerConfig.frequencyForDiscoverer, "1");
       ConsumerUtil.testDynamicCollector(config, testStream, consumerName, false,
           rootDirs, conf, testStream, COLLECTOR_PREFIX);
     }

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
@@ -271,7 +271,6 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
         false);
   }
 
-
   @AfterTest
   public void cleanup() throws IOException {
     super.cleanup();

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
@@ -75,7 +75,7 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
     ConsumerUtil.testMarkAndReset(config, testStream, consumerName, false);
   }
 
-  @Test(timeOut = 80000)
+  @Test
     public void testDynamicCollector() throws Exception {
       ClientConfig config = loadConfig();
       config.set(DatabusConsumerConfig.databusRootDirsConfig,

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumer.java
@@ -75,7 +75,7 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
     ConsumerUtil.testMarkAndReset(config, testStream, consumerName, false);
   }
 
-  @Test(timeOut = 10000)
+  @Test(timeOut = 80000)
     public void testDynamicCollector() throws Exception {
       ClientConfig config = loadConfig();
       config.set(DatabusConsumerConfig.databusRootDirsConfig,
@@ -83,10 +83,11 @@ public class TestDatabusConsumer extends TestAbstractDatabusConsumer {
       config.set(DatabusConsumerConfig.checkpointDirConfig, ck14);
       config.set(MessagingConsumerConfig.relativeStartTimeConfig,
           relativeStartTime);
-      ConsumerUtil.testDynamicCollector(config, testStream, consumerName, false,rootDirs,conf,testStream,COLLECTOR_PREFIX);
+      config.set(DatabusConsumerConfig.initialDelayForDiscoverer, "1");
+      config.set(DatabusConsumerConfig.frequencyForDiscoverer, "1");
+      ConsumerUtil.testDynamicCollector(config, testStream, consumerName, false,
+          rootDirs, conf, testStream, COLLECTOR_PREFIX);
     }
-
-
 
   @Test
   public void testMarkAndResetWithStartTime() throws Exception {

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumerCollectorStream.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumerCollectorStream.java
@@ -87,7 +87,7 @@ public class TestDatabusConsumerCollectorStream
     config.set(DatabusConsumerConfig.databusRootDirsConfig,
         rootDirs[0].toUri().toString() + ","
             + rootDirs[1].toUri().toString() + ","
-            + rootDirs[0].toUri().toString());
+            + rootDirs[2].toUri().toString());
     config.set(DatabusConsumerConfig.checkpointDirConfig, ck4);
     config.set(MessagingConsumerConfig.relativeStartTimeConfig,
         relativeStartTime);
@@ -135,7 +135,7 @@ public class TestDatabusConsumerCollectorStream
     config.set(DatabusConsumerConfig.databusRootDirsConfig,
         rootDirs[0].toUri().toString() + ","
             + rootDirs[1].toUri().toString() + ","
-            + rootDirs[0].toUri().toString());
+            + rootDirs[2].toUri().toString());
     config.set(DatabusConsumerConfig.checkpointDirConfig, ck8);
     config.set(MessagingConsumerConfig.relativeStartTimeConfig,
         relativeStartTime);

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumerMultipleCollectors.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumerMultipleCollectors.java
@@ -78,6 +78,7 @@ public class TestDatabusConsumerMultipleCollectors
       consumer.init(testStream, consumerName, null, config);
     } catch (Exception e) {
       th = e;
+      e.printStackTrace();
     }
     Assert.assertNotNull(th);
     Assert.assertTrue(th instanceof IllegalArgumentException);

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumerMultipleCollectors.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/databus/TestDatabusConsumerMultipleCollectors.java
@@ -78,7 +78,6 @@ public class TestDatabusConsumerMultipleCollectors
       consumer.init(testStream, consumerName, null, config);
     } catch (Exception e) {
       th = e;
-      e.printStackTrace();
     }
     Assert.assertNotNull(th);
     Assert.assertTrue(th instanceof IllegalArgumentException);

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
@@ -441,13 +441,30 @@ public class ConsumerUtil {
     String dataFile = TestUtil.files[2];
     TestUtil.setUpCollectorDataFiles(fs, collectorDir, dataFile);
     //wait for the new messages to be consumed by the new partition readers
-   // Thread.sleep(12000);
     for (i = 0; i < 100; i++) {
       Message msg = consumer.next();
       Assert.assertEquals(getMessage(msg.getData().array(), hadoop),
           MessageUtil.constructMessage(i));
     }
-    fs.delete(collectorDir,true);
+    //reset the consumer
+    consumer.mark();
+    consumer.reset();
+    //create one more collector sub directory
+    Path collectorDir2 = new Path(rootDirs[0].toUri().toString(),
+        "data/" + testStream + "/" + COLLECTOR_PREFIX + "9");
+    fs.mkdirs(collectorDir2);
+    dataFile = TestUtil.files[2];
+    TestUtil.setUpCollectorDataFiles(fs, collectorDir2, dataFile);
+
+    //wait for the new messages to be consumed by the new partition readers
+    for (i = 0; i < 100; i++) {
+      Message msg = consumer.next();
+      Assert.assertEquals(getMessage(msg.getData().array(), hadoop),
+          MessageUtil.constructMessage(i));
+    }
+
+    fs.delete(collectorDir, true);
+    fs.delete(collectorDir2,true);
     consumer.close();
   }
 

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
@@ -416,9 +416,8 @@ public class ConsumerUtil {
   }
 
   public static void testDynamicCollector(ClientConfig config, String streamName,
-                                          String consumerName, boolean hadoop, Path[] rootDirs,
-                                          Configuration conf, String testStream,
-                                          String COLLECTOR_PREFIX) throws Exception {
+      String consumerName, boolean hadoop, Path[] rootDirs, Configuration conf,
+      String testStream, String COLLECTOR_PREFIX) throws Exception {
 
     AbstractMessagingDatabusConsumer consumer = createConsumer(hadoop);
     consumer.init(streamName, consumerName, null, config);

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
@@ -123,7 +123,6 @@ public class ConsumerUtil {
       markedcounter1[i] = counter[i];
       markedcounter2[i] = counter[i];
     }
-       // TODO fix bug
     for (int i = 0; i < totalMessages / 2; i++) {
       Message msg = consumer.next();
       String msgStr = getMessage(msg.getData().array(), hadoop);
@@ -441,30 +440,8 @@ public class ConsumerUtil {
     fs.mkdirs(collectorDir);
     String dataFile = TestUtil.files[2];
     TestUtil.setUpCollectorDataFiles(fs, collectorDir, dataFile);
-
-    ((DatabusConsumer) consumer).createPartitionReaders();
-    // Read consumer id
-    String consumerIdStr = config.getString(MessagingConsumerConfig.consumerIdInGroupConfig,
-        MessagingConsumerConfig.DEFAULT_CONSUMER_ID);
-    String[] id = consumerIdStr.split("/");
-    Integer consumerNumber = Integer.parseInt(id[0]);
-    StringBuilder suffix = new StringBuilder();
-    suffix.append(streamName);
-    suffix.append("-");
-    suffix.append(consumerName);
-    suffix.append("-");
-    suffix.append(consumerNumber);
-
-    Map<PartitionId, PartitionReader> readers = ((DatabusConsumer) consumer).getPartitionReaders();
-    Set<PartitionReader> startedReaders = ((DatabusConsumer) consumer).getStartedPartitionReaders();
-    for (PartitionReader reader : readers.values()) {
-      if(startedReaders.contains(reader)){
-        continue;
-      }
-      reader.start(suffix.toString());
-      startedReaders.add(reader);
-    }
-
+    Thread.sleep(60 * 1000);
+    //wait for the new messages to be consumed by the new partition readers
     for (i = 0; i < 100; i++) {
       Message msg = consumer.next();
       Assert.assertEquals(getMessage(msg.getData().array(), hadoop),

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
@@ -440,7 +440,6 @@ public class ConsumerUtil {
     fs.mkdirs(collectorDir);
     String dataFile = TestUtil.files[2];
     TestUtil.setUpCollectorDataFiles(fs, collectorDir, dataFile);
-    Thread.sleep(60 * 1000);
     //wait for the new messages to be consumed by the new partition readers
     for (i = 0; i < 100; i++) {
       Message msg = consumer.next();

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
@@ -126,22 +126,6 @@ public class ConsumerUtil {
        // TODO fix bug
     for (int i = 0; i < totalMessages / 2; i++) {
       Message msg = consumer.next();
-      System.out.println("AAAAA" +i);
-      if(i == 50){
-                   System.out.println("50");
-                 }
-      if(i == 100){
-              System.out.println("100");
-            }
-      if(i == 200){
-        System.out.println("200");
-      }
-      if(i == 300){
-             System.out.println("300");
-           }
-      if(i == 400){
-             System.out.println("400");
-           }
       String msgStr = getMessage(msg.getData().array(), hadoop);
       for (int m = 0;  m < numCounters; m++) {
         if (msgStr.equals(MessageUtil.constructMessage(counter[m]))) {
@@ -155,8 +139,6 @@ public class ConsumerUtil {
     }
 
     consumer.reset();
-
-    System.out.println(totalMessages);
 
     for (int i = 0; i < totalMessages / 2; i++) {
       Message msg = consumer.next();

--- a/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
+++ b/messaging-client-databus/src/test/java/com/inmobi/messaging/consumer/util/ConsumerUtil.java
@@ -441,6 +441,7 @@ public class ConsumerUtil {
     String dataFile = TestUtil.files[2];
     TestUtil.setUpCollectorDataFiles(fs, collectorDir, dataFile);
     //wait for the new messages to be consumed by the new partition readers
+   // Thread.sleep(12000);
     for (i = 0; i < 100; i++) {
       Message msg = consumer.next();
       Assert.assertEquals(getMessage(msg.getData().array(), hadoop),

--- a/src/site/apt/developer/MessageConsumerConfig.apt
+++ b/src/site/apt/developer/MessageConsumerConfig.apt
@@ -83,8 +83,6 @@ MessageConsumerConfig
 *--------+-----------+-------------+-------------+
 |databus.consumer.waittime.forcollectorflush|	Optional |	Wait time in milli seconds for consumer to read more messages, if the current file is being written. Applicable only for type COLLECTOR	| 5000 |
 *--------+-----------+-------------+-------------+
-|databus.consumer.collector.discoverer.initial.delay.seconds|	Optional |	Wait time in seconds for consumer to start the discovery of newly added collectors output. Applicable only for type COLLECTOR	| 1800 |
-*--------+-----------+-------------+-------------+
 |databus.consumer.collector.discoverer.frequency.seconds|	Optional |	frequency in seconds for consumer for the discovery of newly added collectors output. Applicable only for type COLLECTOR	| 120  |
 *--------+-----------+-------------+-------------+
 

--- a/src/site/apt/developer/MessageConsumerConfig.apt
+++ b/src/site/apt/developer/MessageConsumerConfig.apt
@@ -83,7 +83,7 @@ MessageConsumerConfig
 *--------+-----------+-------------+-------------+
 |databus.consumer.waittime.forcollectorflush|	Optional |	Wait time in milli seconds for consumer to read more messages, if the current file is being written. Applicable only for type COLLECTOR	| 5000 |
 *--------+-----------+-------------+-------------+
-|databus.consumer.collector.discoverer.frequency.seconds|	Optional |	frequency in seconds for consumer for the discovery of newly added collectors output. Applicable only for type COLLECTOR	| 120  |
+|databus.consumer.collector.discoverer.frequency.seconds|	Optional |	frequency in seconds for consumer for the discovery of newly added collectors output. Applicable only for type COLLECTOR	| 1200  |
 *--------+-----------+-------------+-------------+
 
   << HadoopConsumer configuration propertes>>

--- a/src/site/apt/developer/MessageConsumerConfig.apt
+++ b/src/site/apt/developer/MessageConsumerConfig.apt
@@ -69,7 +69,7 @@ MessageConsumerConfig
 |messaging.consumer.group.membership |	Optional | ConsumerNumber in the consumer group. (consumerNumber/totalConsumers) |	1/1 |
 *--------+-----------+-------------+-------------+
 |messaging.consumer.clusternames   | Optional    | user specific cluster name for each root dir.| for databus consumer : databusCluster0,databusCluster1,... \ |
-|                                  |             | This property is <<Mondatory>> in case if user wants to remove a rootdir| hadoop consumer : hadoopcluster0,hadoopcluster1,... |
+|                                  |             | This property is <<Mandatory>> in case if user wants to remove a rootdir| hadoop consumer : hadoopcluster0,hadoopcluster1,... |
 *--------+-----------+-------------+-------------+
 
     <<DatabusConsumer configuraton properties>>
@@ -82,6 +82,10 @@ MessageConsumerConfig
 |databus.consumer.stream.type |	Optional |	Different stream types consumable. The supported types are COLLECTOR, LOCAL, MERGED	|COLLECTOR |
 *--------+-----------+-------------+-------------+
 |databus.consumer.waittime.forcollectorflush|	Optional |	Wait time in milli seconds for consumer to read more messages, if the current file is being written. Applicable only for type COLLECTOR	| 5000 |
+*--------+-----------+-------------+-------------+
+|databus.consumer.collector.discoverer.initial.delay.seconds|	Optional |	Wait time in seconds for consumer to start the discovery of newly added collectors output. Applicable only for type COLLECTOR	| 1800 |
+*--------+-----------+-------------+-------------+
+|databus.consumer.collector.discoverer.frequency.seconds|	Optional |	frequency in seconds for consumer for the discovery of newly added collectors output. Applicable only for type COLLECTOR	| 120  |
 *--------+-----------+-------------+-------------+
 
   << HadoopConsumer configuration propertes>>


### PR DESCRIPTION
This change is to enable dynamic discovery of collector sub-directory additions after the databus consumer initialisations has been done