### PR TITLE
Graphite fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Release 4.1.3
+
+Features:
+  1. Dynamic discovery of collectors in  messaging-client-databus
+
 Release 4.1.1
 
 Incompatible changes:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 Release 4.1.3
 
 Features:
-  1. Dynamic discovery of collectors in  messaging-client-databus
+  1. Dynamic discovery of collectors in DatabusConsumer
 
 Release 4.1.2
 

--- a/messaging-client-core/src/main/java/com/inmobi/messaging/util/GraphiteStatsEmitter.java
+++ b/messaging-client-core/src/main/java/com/inmobi/messaging/util/GraphiteStatsEmitter.java
@@ -20,6 +20,7 @@ package com.inmobi.messaging.util;
  * #L%
  */
 
+import com.inmobi.messaging.consumer.MessageConsumerMetricsConstants;
 import com.inmobi.messaging.publisher.TopicStatsExposer;
 import com.inmobi.stats.StatsExposer;
 
@@ -39,6 +40,7 @@ public class GraphiteStatsEmitter extends RunnableStatsEmitter {
   public static final String FIELD_SEPARATOR = " ";
   private static final String NEW_LINE = "\n";
   private static final Log LOG = LogFactory.getLog(GraphiteStatsEmitter.class);
+  private static final String TOPIC = "topic";
 
   private String metricPrefix;
   private String graphiteHost;
@@ -69,6 +71,13 @@ public class GraphiteStatsEmitter extends RunnableStatsEmitter {
           Map<String, Number> stats = exposer.getStats();
           Map<String, String> context = exposer.getContexts();
           String topic = context.get(TopicStatsExposer.TOPIC_CONTEXT_NAME);
+          /**
+           * Publisher will be having topic set as category in the statsexposer,
+           * but for consumers topic is set as topicName for the statsexposer.
+           */
+          if(null == topic){
+            topic = context.get(MessageConsumerMetricsConstants.TOPIC_CONTEXT);
+          }
           for (Map.Entry<String, Number> entry : stats.entrySet()) {
             lines.append(metricPrefix).append(topic).append(METRIC_SEPARATOR)
                 .append(entry.getKey());

--- a/messaging-client-core/src/main/java/com/inmobi/messaging/util/GraphiteStatsEmitter.java
+++ b/messaging-client-core/src/main/java/com/inmobi/messaging/util/GraphiteStatsEmitter.java
@@ -64,7 +64,7 @@ public class GraphiteStatsEmitter extends RunnableStatsEmitter {
     if (null != statsExposers) {
       synchronized (statsExposers) {
         final StringBuilder lines = new StringBuilder();
-        long timestamp = System.currentTimeMillis();
+        long timestamp = System.currentTimeMillis() / 1000;
         for (StatsExposer exposer : statsExposers) {
           Map<String, Number> stats = exposer.getStats();
           Map<String, String> context = exposer.getContexts();

--- a/messaging-client-core/src/main/java/com/inmobi/messaging/util/GraphiteStatsEmitter.java
+++ b/messaging-client-core/src/main/java/com/inmobi/messaging/util/GraphiteStatsEmitter.java
@@ -40,7 +40,6 @@ public class GraphiteStatsEmitter extends RunnableStatsEmitter {
   public static final String FIELD_SEPARATOR = " ";
   private static final String NEW_LINE = "\n";
   private static final Log LOG = LogFactory.getLog(GraphiteStatsEmitter.class);
-  private static final String TOPIC = "topic";
 
   private String metricPrefix;
   private String graphiteHost;

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,11 @@
     <name>InMobi</name>
     <url>https://github.com/InMobi</url>
   </organization>
- 
+  <!--parent>
+    <artifactId>inmobi-master-pom</artifactId>
+    <groupId>com.inmobi</groupId>
+    <version>1.0.4</version>
+  </parent--> 
   <inceptionYear>2012</inceptionYear>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  
+  <parent>
+    <artifactId>inmobi-master-pom</artifactId>
+    <groupId>com.inmobi</groupId>
+    <version>1.0.4</version>
+  </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.inmobi.messaging</groupId>
   <artifactId>messaging-client-parent</artifactId>
@@ -11,11 +17,6 @@
     <name>InMobi</name>
     <url>https://github.com/InMobi</url>
   </organization>
-  <!--parent>
-    <artifactId>inmobi-master-pom</artifactId>
-    <groupId>com.inmobi</groupId>
-    <version>1.0.4</version>
-  </parent--> 
   <inceptionYear>2012</inceptionYear>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.inmobi.messaging</groupId>
   <artifactId>messaging-client-parent</artifactId>
-  <version>4.1.4-SNAPSHOT</version>
+  <version>4.1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Pintail</name>
   <url>https://github.com/InMobi/pintail</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  
-  <parent>
-    <artifactId>inmobi-master-pom</artifactId>
-    <groupId>com.inmobi</groupId>
-    <version>1.0.4</version>
-  </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.inmobi.messaging</groupId>
   <artifactId>messaging-client-parent</artifactId>
-  <version>4.1.3-SNAPSHOT</version>
+  <version>4.1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Pintail</name>
   <url>https://github.com/InMobi/pintail</url>
@@ -17,6 +11,7 @@
     <name>InMobi</name>
     <url>https://github.com/InMobi</url>
   </organization>
+ 
   <inceptionYear>2012</inceptionYear>
   <licenses>
     <license>


### PR DESCRIPTION
1)GraphiteStatsEmitter sends metrics along with timestamp in milliseconds. But graphite end point takes timestamp in seconds. In result, our metrics get stored with few centuries ahead time value

2)for consumer stats - topic is different and publisher it is different(context) 